### PR TITLE
Added omitempty annotation

### DIFF
--- a/exp/api/v1alpha3/azuremachinepool_types.go
+++ b/exp/api/v1alpha3/azuremachinepool_types.go
@@ -125,7 +125,7 @@ type (
 
 		// Instances is the VM instance status for each VM in the VMSS
 		// +optional
-		Instances []*AzureMachinePoolInstanceStatus `json:"instances"`
+		Instances []*AzureMachinePoolInstanceStatus `json:"instances,omitempty"`
 
 		// Version is the Kubernetes version for the current VMSS model
 		// +optional


### PR DESCRIPTION
**What this PR does / why we need it**:

Field `AzureMachinePool`/`Status`/`Instances` is optional:

```
AzureMachinePoolStatus struct {
  	...
	// Instances is the VM instance status for each VM in the VMSS
	// +optional
	Instances []*AzureMachinePoolInstanceStatus ...
```

But the JSON `struct tags` don't include the `omitempty` option.

This means that, when creating an `AzureMachinePool` CR with golang, the JSON representation of the `Instances` field will be set to null:

```
apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
kind: AzureMachinePool
...
status:
  ...
  instances: null
  ...
```

Unluckily this will lead to an error if the `Instances` field is not set at all in the go struct:

```
AzureMachinePool.exp.infrastructure.cluster.x-k8s.io "mp1" is invalid: status.instances: Invalid value: "null": status.instances in body must be of type array: "null"
```

I suggest adding the `omitempty` option to avoid the field from being present in the JSON representation when not set in the Go struct.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

None found

**Special notes for your reviewer**:

Nothing to add.

**TODOs**:

- [X] squashed commits
- [X] includes documentation
- [X] adds unit tests

**Release note**:
```release-note
Added omitempty option to the AzureMachinePool/Status/Instances field to avoid null errors when the field is not set.
```
